### PR TITLE
💄 Refactor code to add account registration modal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,31 @@
 <script setup>
-// This starter template is using Vue 3 <script setup> SFCs
-// Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
-import Account from "./components/Account.vue";
+import { ref } from 'vue';
+import AccountModal from './components/AccountModal.vue';
+import Account from './components/Account.vue';
+
+const accountModal = ref(null);
+
+function openModal() {
+  accountModal.value.open();
+}
 </script>
 
 <template>
-  <div class="container">    
-    <h2> 계좌 등록하기 </h2>
-    <Account />
+  <div id="app">
+    <div class="button-container">
+      <button @click="openModal">계좌 등록하기</button>
+    </div>
+
+    <AccountModal ref="accountModal">
+      <Account />
+    </AccountModal>
   </div>
 </template>
 
-<style scoped>
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #249b73);
+<style>
+.button-container {
+  display: flex;
+  justify-content: flex-end; /* 우측 정렬 */
+  padding: 20px; /* 상단 및 우측 여백 */
 }
 </style>

--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -47,3 +47,9 @@ async function submitAccount() {
   </div>
 </template>
 
+<style>
+input {
+  margin-right: 10px; /* 상하좌우 마진 설정 */
+  width: calc(100% - 20px); /* 양쪽 마진을 고려한 너비 설정 */
+}
+</style>

--- a/src/components/AccountModal.vue
+++ b/src/components/AccountModal.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="modal-backdrop" v-if="isVisible" @click.self="close">
+      <div class="modal-content">
+        <slot></slot> <!-- Account 컴포넌트를 여기에 삽입합니다 -->
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  import { ref } from 'vue';
+  
+  export default {
+    setup() {
+      const isVisible = ref(false);
+  
+      function open() {
+        isVisible.value = true;
+      }
+  
+      function close() {
+        isVisible.value = false;
+      }
+  
+      return { isVisible, open, close };
+    }
+  };
+  </script>
+  
+  <style>
+  .modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .modal-content {
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+  }
+  </style>
+  


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a modal for account registration in the application. The account registration form is now displayed in a modal when the user clicks on the "계좌 등록하기" button.
> 
> ## What changed
> - The `Account` component is now wrapped inside a new `AccountModal` component.
> - A new `AccountModal` component has been created. This component uses Vue's `ref` to control the visibility of the modal.
> - The `openModal` function has been added to the `App.vue` component to open the modal.
> - The account registration button has been moved to a new `button-container` div.
> - Styling has been added to the `button-container` div and the `input` element in the `Account` component.
> - The `AccountModal` component has been styled to look like a modal.
> 
> ## How to test
> 1. Pull the changes from this pull request.
> 2. Run the application.
> 3. Click on the "계좌 등록하기" button. The account registration form should appear in a modal.
> 4. Fill out the form and submit it. The modal should close and the account should be registered.
> 
> ## Why make this change
> This change improves the user experience by providing a clear and focused area for account registration. The modal provides a better separation between the account registration form and the rest of the application.
</details>