### PR TITLE
✨ Refactor PortfolioTable.vue component to group assets by class

### DIFF
--- a/src/components/PortfolioTable.vue
+++ b/src/components/PortfolioTable.vue
@@ -5,36 +5,51 @@
     <table v-if="portfolio && portfolio.positions && portfolio.positions.length > 0">
       <thead>
         <tr>
-          <th>종목코드</th>
-          <th>보유수량</th>
-          <th>평단가</th>
-          <th>총 가치</th>
+          <th>이름</th>
+          <th>비중</th>
+          <th>가치</th>
           <th>수익률</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="position in portfolio.positions" :key="position.symbol">
-          <td>{{ position.asset.label }}</td>
-          <td>{{ position.quantity }}</td>
-          <td>{{ toCurrency(position.average_buy_price) }}</td>
-          <td>{{ toCurrency(position.total_amount) }}</td>
-          <td>{{ position.rtn ? toPercentage(position.rtn) : '-' }}</td>
-        </tr>
+        <template v-for="group in groupedAssets" :key="group.name">
+          <tr @click="toggleGroup(group.name)">
+            <td><strong>{{ group.name }}</strong></td>
+            <td>{{ toPercentage(group.percentage) }}</td>
+            <td>{{ toCurrency(group.total_value) }}</td>
+            <td>{{ toPercentage(group.average_rtn) }}</td>
+          </tr>
+          <tr v-if="isVisible(group.name)" v-for="asset in group.positions" :key="asset.asset.symbol">
+            <td>— {{ asset.asset.label }}</td>
+            <td>{{ toPercentage(calcWeight(asset.total_amount, portfolio.total_value)) }}</td>
+            <td>{{ toCurrency(asset.total_amount) }}</td>
+            <td>{{ toPercentage(asset.rtn) }}</td>
+          </tr>
+        </template>
       </tbody>
     </table>
     <p v-else>포트폴리오 정보를 불러오는 중...</p>
   </div>
 </template>
 
+
 <script setup>
 import { onMounted, ref } from 'vue';
 import axios from 'axios';
 
-const portfolio = ref({
-  total_value: 0,
-  cash_balance: 0,
-  positions: []
-});
+const portfolio = ref({ total_value: 0, positions: [] });
+const groupedAssets = ref([]);
+
+const showDetails = ref({});
+
+function toggleGroup(groupName) {
+  showDetails.value[groupName] = !showDetails.value[groupName];
+}
+
+function isVisible(groupName) {
+  return !!showDetails.value[groupName];
+}
+
 
 // 숫자를 통화 형식으로 변환
 function toCurrency(value) {
@@ -45,6 +60,11 @@ function toCurrency(value) {
 function toPercentage(value) {
   return `${(value * 100).toFixed(2)}%`;
 }
+
+function calcWeight(value, total) {
+  return value / total;
+}
+
 function transformPortfolioData(data) {
   // API 응답에서 positions 배열 복사
   const positionsCopy = [...data.positions];
@@ -69,13 +89,45 @@ function transformPortfolioData(data) {
   };
 }
 
+function groupAssetsByClass(positions, totalValue) {
+  // 자산군별로 그룹화된 객체를 생성합니다.
+  const assetGroups = {};
+
+  positions.forEach(position => {
+    const assetClass = position.asset.asset_class;
+    if (!assetGroups[assetClass]) {
+      // 자산군별로 초기 객체를 생성합니다.
+      assetGroups[assetClass] = {
+        name: assetClass,
+        total_value: 0,
+        positions: [],
+        average_rtn: 0,
+        total_rtn: 0
+      };
+    }
+
+    // 자산군에 포지션을 추가하고, 가치와 수익률을 누적합니다.
+    assetGroups[assetClass].positions.push(position);
+    assetGroups[assetClass].total_value += position.total_amount;
+    assetGroups[assetClass].total_rtn += position.total_amount * position.rtn;
+  });
+
+  // 각 자산군의 비중과 평균 수익률을 계산합니다.
+  Object.values(assetGroups).forEach(group => {
+    group.percentage = group.total_value / totalValue;
+    group.average_rtn = group.total_value > 0 ? (group.total_rtn / group.total_value) : 0;
+  });
+
+  return Object.values(assetGroups); // 배열로 변환하여 반환합니다.
+}
+
 onMounted(async () => {
   try {
     const response = await axios.get('http://localhost:8000/portfolio');
-    console.log("데이터 로딩 성공:", response.data);
     // 데이터 변환 함수를 호출하여 현금 잔액을 포함한 포트폴리오 데이터를 생성
     const transformedData = transformPortfolioData(response.data);
     portfolio.value = transformedData;
+    groupedAssets.value = groupAssetsByClass(portfolio.value.positions, portfolio.value.total_value);
   } catch (error) {
     console.error("포트폴리오 데이터를 가져오는데 실패했습니다.", error);
   }
@@ -88,7 +140,8 @@ table {
   border-collapse: collapse;
 }
 
-th, td {
+th,
+td {
   border: 1px solid #ddd;
   text-align: left;
   padding: 8px;


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the `PortfolioTable.vue` component to group portfolio positions by asset class and display them in a collapsible format. It also changes the table headers and the data displayed for each position.
> 
> ## What changed
> - The table headers were changed from 종목코드, 보유수량, 평단가, 총 가치 to 이름, 비중, 가치, 수익률.
> - The portfolio positions are now grouped by asset class. Each group can be expanded or collapsed by clicking on the group name.
> - The portfolio data is now transformed to include the grouped assets and their total value, average return, and weight in the portfolio.
> - The `PortfolioTable.vue` component now includes methods to toggle the visibility of each group and calculate the weight of each position in the portfolio.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the application and navigate to the page that includes the `PortfolioTable.vue` component.
> 3. Verify that the portfolio positions are grouped by asset class and that you can expand and collapse each group.
> 4. Verify that the table headers and the data displayed for each position match the changes described above.
> 5. Verify that the total value, average return, and weight of each group are calculated correctly.
> 
> ## Why make this change
> Grouping the portfolio positions by asset class and displaying them in a collapsible format makes it easier for users to view and understand their portfolio. The changes to the table headers and the data displayed for each position provide users with more relevant information about their portfolio.
</details>