### PR TITLE
💄 Refactor account form layout and button group

### DIFF
--- a/src/components/Account.vue
+++ b/src/components/Account.vue
@@ -47,8 +47,10 @@ function btnCloseClicked() {
         <label for="secretKey">SECRET_KEY:</label>
         <input id="secretKey" v-model="accountData.secret_key" type="password" required>
       </div>
-      <button type="submit">계좌 등록</button>
-      <button @click="btnCloseClicked">닫기</button>
+      <div class="button-group">
+        <button @click="btnCloseClicked">닫기</button>
+        <button type="submit">계좌 등록</button>
+      </div>
       <p v-if="accountSubmissionResultMessage">{{ accountSubmissionResultMessage }}</p>
     </form>
   </div>
@@ -56,7 +58,21 @@ function btnCloseClicked() {
 
 <style>
 input {
-  margin-right: 10px; /* 상하좌우 마진 설정 */
-  width: calc(100% - 20px); /* 양쪽 마진을 고려한 너비 설정 */
+  margin-right: 10px;
+  /* 상하좌우 마진 설정 */
+  width: calc(100% - 20px);
+  /* 양쪽 마진을 고려한 너비 설정 */
+}
+
+.button-group {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.button-group button {
+  flex: 1;
+  /* 버튼들이 동일한 너비를 가지도록 설정 */
+  margin: 5px;
 }
 </style>


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces changes to the `Account.vue` component. The changes include reordering the buttons and adding a new CSS class to style the buttons.
> 
> ## What changed
> The '계좌 등록' (Register Account) and '닫기' (Close) buttons have been reordered and wrapped in a new div with the class `button-group`. This class has been styled to display the buttons in a flex container, with space between them and equal widths. The margin for the buttons has also been adjusted.
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Navigate to the Account component in your application.
> 3. Verify that the '계좌 등록' and '닫기' buttons are displayed side by side, with equal widths and space between them.
> 4. Test the functionality of the buttons to ensure that the changes have not affected their operation.
> 
> ## Why make this change
> These changes improve the visual layout of the Account component, making it more user-friendly. By displaying the buttons side by side and with equal widths, we ensure a consistent and clean look and feel. The space between the buttons also improves usability by preventing accidental clicks.
</details>