### PR TITLE
♻️ Refactor PortfolioTable component layout and add footer

### DIFF
--- a/src/components/PortfolioTable.vue
+++ b/src/components/PortfolioTable.vue
@@ -1,19 +1,21 @@
 <template>
   <div>
-    <h2>포트폴리오</h2>
-    <p v-if="portfolio">총 가치: {{ toCurrency(portfolio.total_value) }}</p>
-    <Panel>
-      <div class="portfolio-meter-group">
-        <MeterGroup :value="meterValues" labelPosition="end" labelOrientation="horizontal" />
-      </div>
-      <Panel>
-        <TreeTable :value="treeTableData">
-          <Column field="name" header="이름" expander></Column>
-          <Column field="percentage" header="비중"></Column>
-          <Column field="total_value" header="가치"></Column>
-          <Column field="rtn" header="수익률"></Column>
-        </TreeTable>
-      </Panel>
+    <h1>포트폴리오</h1>
+    <div class="portfolio-meter-group">
+      <MeterGroup :value="meterValues" labelPosition="end" labelOrientation="horizontal" />
+    </div>
+    <Panel v-if="portfolio">
+      <TreeTable :value="treeTableData">
+        <Column class="w-5" field="name" header="이름" expander></Column>
+        <Column field="percentage" header="비중"></Column>
+        <Column field="total_value" header="가치"></Column>
+        <Column field="rtn" header="수익률"></Column>
+        <template #footer>
+          <div class="right-0">
+            <span>{{ toCurrency(portfolio.total_value) }}</span>
+          </div>
+        </template>
+      </TreeTable>
     </Panel>
   </div>
 </template>


### PR DESCRIPTION

### TL;DR

This PR refactors the PortfolioTable.vue with improved UI elements and code readability.

### What changed?

Changes include updating the heading, rearranging the `portfolio-meter-group` and the `Panel` component and adding footer in the `TreeTable`. The total portfolio value is moved to the footer of the `TreeTable`.

### How to test?

Check the layout and behaviour of the Portfolio component after the changes.

### Why make this change?

This was done to improve the layout of the portfolio table and increase clarity of code.

---

